### PR TITLE
[#1] better build pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,34 @@ The approach to schema extraction is inspired by [DDL.js][js-ddl]. Collimator's 
 
 [js-ddl]: https://github.com/moll/js-ddl
 
+# Development
+
+Install dependencies with:
+
+```bash
+npm install
+```
+
+Run the tests with:
+
+```bash
+gulp
+```
+
+Run unit test coverage with:
+
+```bash
+gulp coverage
+```
+
+Enter development mode with:
+
+```bash
+gulp dev
+```
+
+This will watch the `src` and `spec` directories and run `gulp` automatically when a change is detected. Note that it will not run the tests until it detects a change, so you may prefer to run it with `gulp & gulp dev`.
+
 # Installation
 
 For now, clone this Git repository, followed by `npm install`.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,4 @@
 var gulp     = require('gulp');
-var plumber  = require('gulp-plumber');
 var istanbul = require('gulp-istanbul');
 var jasmine  = require('gulp-jasmine');
 var jscs     = require('gulp-jscs');
@@ -7,22 +6,26 @@ var jscs     = require('gulp-jscs');
 var src  = './src/**/*.js';
 var spec = './spec/**/*.js';
 
-gulp.task('test', function(done) {
-  gulp.src(src)
-    .pipe(istanbul({includeUntested: true}))
-    .pipe(istanbul.hookRequire())
-    .on('finish', function() {
-      gulp.src(spec)
-        .pipe(jasmine())
-        .pipe(istanbul.writeReports({
-          dir: './dist/coverage',
-          reporters: ['html', 'text']
-        }))
-        .on('end', done);
-    });
+gulp.task('test', function() {
+  return gulp.src(spec)
+      .pipe(jasmine());
 });
 
-gulp.task('style', function(done) {
+gulp.task('coverage', function() {
+  return gulp.src(src)
+      .pipe(istanbul())
+      .pipe(istanbul.hookRequire())
+      .on('finish', function() {
+        gulp.src(spec)
+          .pipe(jasmine())
+          .pipe(istanbul.writeReports({
+            dir: './dist/coverage',
+            reporters: ['html', 'text']
+          }));
+      });
+});
+
+gulp.task('style', function() {
   return gulp.src(src)
     .pipe(jscs({
       preset: 'google'
@@ -31,6 +34,6 @@ gulp.task('style', function(done) {
 
 gulp.task('default', ['style', 'test']);
 
-gulp.task('dev', ['default'], function() {
+gulp.task('dev', function() {
   gulp.watch([src, spec], ['default']);
 });

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "collimator",
   "version": "0.0.0",
   "description": "Reflection & Introspection for PostgreSQL Databases",
-  "main": "index.js",
+  "main": "src/collimator.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "gulp"
   },
   "author": "",
   "license": "BSD-2-Clause",
@@ -18,7 +18,6 @@
     "gulp-jasmine": "~2.0.1",
     "gulp-istanbul": "~0.10.0",
     "rewire": "~2.3.4",
-    "gulp-plumber": "~1.0.1",
     "gulp-jscs": "~2.0.0",
     "gulp-watch": "~4.3.5"
   }


### PR DESCRIPTION
Addresses #1
- Remove
- Do not run code coverage by default as it causes Gulp watch to bomb out if it fails
- Add documentation on how to run build scripts etc
- Add `gulp coverage` task
## Test script

Follow my docs in README.md and **assert that** it behaves as you expect.

Assert that:
- Making a JSCS error in src/ somewhere does not cause `gulp dev` to fall over
- Making a unit test fail does not cause `gulp dev` to fall over
- `gulp coverage` works
