### PR TITLE
Moves coverage output to `build/coverage/`

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,7 +27,7 @@ gulp.task('coverage', function() {
         gulp.src(spec)
           .pipe(jasmine())
           .pipe(istanbul.writeReports({
-            dir: './dist/coverage',
+            dir: './build/coverage',
             reporters: ['html', 'text']
           }));
       });


### PR DESCRIPTION
## Moves coverage output to `build/coverage/`
### Description
- Per [Gav's comment](Moves coverage output to `build/coverage`), this moves the Istanbul coverage output to `build/coverage/`
- No need to modify the `.gitignore`; `coverage/` is already there
### Test
- If necessary, run `npm install`
- Run `gulp coverage`
- **Assert that** output is written to `build/coverage/`
- **Assert that** git is ignoring the `build/coverage/` directory
