### PR TITLE
Aggregate primary keys into an array

### DIFF
--- a/api.md
+++ b/api.md
@@ -125,7 +125,7 @@ This table information consists of an array of objects. Each element has the
 following properties:
 
 `name` - The name of the enumerated table
-`primaryKey` - The name of the column containing the primary key
+`primaryKeys` - An array of column names that are primary keys
 
 ### Params:
 

--- a/src/inspectors/tables.js
+++ b/src/inspectors/tables.js
@@ -10,7 +10,7 @@ var query = require('../util/fileQuery');
  * following properties:
  *
  * `name` - The name of the enumerated table
- * `primaryKey` - The name of the column containing the primary key
+ * `primaryKeys` - An array of column names that are primary keys
  *
  * @function collimator.tables
  * @param {Promise.<Database>} db - The pg-promise connection

--- a/src/inspectors/tables.sql
+++ b/src/inspectors/tables.sql
@@ -1,6 +1,6 @@
 SELECT
   t.table_name AS name,
-  ccu.column_name AS "primaryKey"
+  array_agg(ccu.column_name::text) AS "primaryKeys"
 
 FROM information_schema.tables AS t
 
@@ -10,4 +10,6 @@ ON tc.table_name = t.table_name AND tc.constraint_type = 'PRIMARY KEY'
 JOIN information_schema.constraint_column_usage AS ccu
 ON ccu.constraint_name = tc.constraint_name
 
-WHERE t.table_schema = 'public';
+WHERE t.table_schema = 'public'
+
+GROUP BY t.table_name;


### PR DESCRIPTION
Tables with compound primary keys would result in duplicate name
results in the `tables` inspector. To prevent this, all primary keys
should be aggregated into an array.