### PR TITLE
fix(): Remove explicit coercon to 'manyOrNone' query result mask

### DIFF
--- a/spec/util/fileQuery.js
+++ b/spec/util/fileQuery.js
@@ -3,10 +3,6 @@ import fileQuery from '../../src/util/fileQuery';
 describe('fileQuery', () => {
   var db;
 
-  global.queryResult = {
-    manyOrNone: 'mockManyOrNoneQueryResult'
-  };
-
   beforeEach(() => {
     db = jasmine.createSpyObj('db', ['query']);
   });
@@ -14,7 +10,7 @@ describe('fileQuery', () => {
   it('runs a query from a file', (done) => {
     fileQuery(db, './testQuery.sql')
       .then((result) => {
-        expect(db.query).toHaveBeenCalledWith('SELECT * FROM test_query;\n', undefined, queryResult.manyOrNone);
+        expect(db.query).toHaveBeenCalledWith('SELECT * FROM test_query;\n', undefined, undefined);
       })
       .then(done);
   });
@@ -22,7 +18,7 @@ describe('fileQuery', () => {
   it('specifies params', (done) => {
     fileQuery(db, './testQuery.sql', 'mockParams')
       .then((result) => {
-        expect(db.query).toHaveBeenCalledWith('SELECT * FROM test_query;\n', 'mockParams', queryResult.manyOrNone);
+        expect(db.query).toHaveBeenCalledWith('SELECT * FROM test_query;\n', 'mockParams', undefined);
       })
       .then(done);
   });

--- a/src/util/fileQuery.js
+++ b/src/util/fileQuery.js
@@ -9,7 +9,6 @@ const readFileP = promisify(readFile);
 
 export default function fileQuery(db, file, params, resultMask) {
   var path = resolvePath(file);
-  resultMask = resultMask || global.queryResult.manyOrNone;
 
   return readFileP(path, 'utf-8')
     .then(query => db.query(query, params, resultMask));


### PR DESCRIPTION
pg-promise automatically defaults to a manyOrNone query type, so no need to explicitly coerce to it in fileQuery. This also avoids a reliability on a global which has been removed in pg-promise 2.