### PR TITLE
refactor: Change default export to export named 'inspect'

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -2,7 +2,7 @@
 
 <!-- Start src/collimator.js -->
 
-## collimator(db)
+## collimator.inspect(db)
 
 Inspect all enumerable table in a database, and return a promise that will
 resolve to information about each table.

--- a/integration-test/index.js
+++ b/integration-test/index.js
@@ -1,7 +1,7 @@
-var pg         = require('pg-promise')();
-var collimator = require('../lib/collimator.js').default;
-var equal      = require('assert').equal;
-var diff       = require('deep-diff').diff;
+var pg      = require('pg-promise')();
+var inspect = require('../lib/collimator').inspect;
+var equal   = require('assert').equal;
+var diff    = require('deep-diff').diff;
 
 var db = pg({database: 'collimator-integration-test'});
 
@@ -71,9 +71,9 @@ var expected = [{
   }
 }];
 
-collimator(db)
+inspect(db)
   .then(function(result) {
-    return diff(result, expected)
+    return diff(result, expected);
   })
   .then(function(diff) {
     equal(diff, undefined);

--- a/spec/collimator.js
+++ b/spec/collimator.js
@@ -1,8 +1,8 @@
-import collimator from '../src/collimator';
-import bluebird   from 'bluebird';
+import * as collimator from '../src/collimator';
+import bluebird        from 'bluebird';
 
-describe('collimator', () => {
-  it('describes the entire database when invoked directly', (done) => {
+describe('collimator.inspect', () => {
+  it('describes the entire database', (done) => {
     var deferred = {
       tables:        bluebird.defer(),
       schema:        bluebird.defer(),
@@ -19,7 +19,7 @@ describe('collimator', () => {
     collimator.__Rewire__('schema', spy.schema);
     collimator.__Rewire__('relationships', spy.relationships);
 
-    collimator('mockDb')
+    collimator.inspect('mockDb')
       .then((result) => {
         expect(spy.tables).toHaveBeenCalledWith('mockDb');
         expect(spy.schema).toHaveBeenCalledWith('mockDb', 'mockTable');

--- a/src/collimator.js
+++ b/src/collimator.js
@@ -20,17 +20,17 @@ import relationships from './inspectors/relationships';
  *   contraints. See `collimator.relationships` for further information on the
  *   structure of this data.
  *
- * @function collimator
+ * @function collimator.inspect
  * @param {Database} db - A pg-promise `Database` instance
  * @returns {Promise.<Object>} A promise that will resolve to the information for each table
  */
-export default function collimator(db) {
-  const inspect = table => bluebird.props(merge(table, {
+export function inspect(db) {
+  const inspectors = table => bluebird.props(merge(table, {
     schema:        schema(db, table.name),
     relationships: relationships(db, table.name)
   }));
 
-  return tables(db).map(inspect);
+  return tables(db).map(inspectors);
 }
 
 export {tables, schema, relationships};


### PR DESCRIPTION
Babel 6 does away with an implicit default export, and makes it an export named 'default'. If the
root function is going to be renamed anyway, it makes more sense to be named 'inspect'.

The top-level function 'collimator(db)' has been renamed to 'collimator.inspect(db)'