### PR TITLE
feat(schema): Format timestamp column types as 'date-time'

### DIFF
--- a/integration-test/index.js
+++ b/integration-test/index.js
@@ -18,8 +18,14 @@ var expected = [{
       id: {type: 'integer'},
       username: {type: 'string'},
       password: {type: 'string'},
-      created_at: {},
-      updated_at: {}
+      created_at: {
+        type: 'string',
+        format: 'date-time'
+      },
+      updated_at: {
+        type: 'string',
+        format: 'date-time'
+      },
     },
 
     required: ['username', 'password']
@@ -53,8 +59,14 @@ var expected = [{
       complete: {
         type: 'boolean'
       },
-      created_at: {},
-      updated_at: {},
+      created_at: {
+        type: 'string',
+        format: 'date-time'
+      },
+      updated_at: {
+        type: 'string',
+        format: 'date-time'
+      },
       owner: {
         type: 'integer'
       }

--- a/integration-test/setup.sql
+++ b/integration-test/setup.sql
@@ -7,8 +7,8 @@ CREATE TABLE tasks
   title character varying(255) NOT NULL,
   description character varying(255),
   complete boolean NOT NULL DEFAULT false,
-  created_at timestamp with time zone,
-  updated_at timestamp with time zone,
+  created_at timestamp with time zone DEFAULT now(),
+  updated_at timestamp with time zone DEFAULT now(),
   owner integer NOT NULL,
   PRIMARY KEY (id)
 );
@@ -18,8 +18,8 @@ CREATE TABLE users
   id serial,
   username character varying(255) NOT NULL,
   password character varying(255) NOT NULL,
-  created_at timestamp with time zone,
-  updated_at timestamp with time zone,
+  created_at timestamp with time zone DEFAULT now(),
+  updated_at timestamp with time zone DEFAULT now(),
   PRIMARY KEY (id)
 );
 

--- a/spec/inspectors/schema.js
+++ b/spec/inspectors/schema.js
@@ -5,10 +5,10 @@ import { table, property, properties, required } from '../../src/inspectors/sche
 
 describe('schema', () => {
   const columns = [
-    {name: 'forename', nullable: false, default: null, type: 'character varying'},
-    {name: 'surname',  nullable: false, default: null, type: 'character varying'},
-    {name: 'age',      nullable: false, default: 30,   type: 'smallint'},
-    {name: 'gender',   nullable: true,  default: null, type: 'character'}
+    {name: 'forename',   nullable: false, default: null, type: 'character varying'},
+    {name: 'surname',    nullable: false, default: null, type: 'character varying'},
+    {name: 'age',        nullable: false, default: 30,   type: 'smallint'},
+    {name: 'gender',     nullable: true,  default: null, type: 'character'}
   ];
 
   describe('schema()', () => {
@@ -77,6 +77,22 @@ describe('schema', () => {
       expect(result).toEqual({
         forename: {
           type: 'string'
+        }
+      });
+    });
+
+    it('converts timestamps to strings with `date-time` format', () => {
+      var result = property({
+        name:     'date_of_birth',
+        nullable: false,
+        default:  null,
+        type:     'time without time zone'
+      });
+
+      expect(result).toEqual({
+        date_of_birth: {
+          type:   'string',
+          format: 'date-time'
         }
       });
     });

--- a/src/inspectors/schema.js
+++ b/src/inspectors/schema.js
@@ -57,30 +57,31 @@ export function properties(columns) {
  */
 export function property(column) {
   const TYPES = {
-    bigserial: 'integer',
-    boolean: 'boolean',
-    'character varying': 'string',
-    character: 'string',
-    date: 'string',
-    bigint: 'integer',
-    'double precision': 'number',
-    integer: 'integer',
-    json: 'object',
-    jsonb: 'object',
-    numeric: 'number',
-    real: 'number',
-    smallint: 'integer',
-    smallserial: 'integer',
-    serial: 'integer',
-    text: 'string',
-    'time without time zone': 'string',
-    'timestamp without time zone': 'string'
+    bigserial:   {type: 'integer'},
+    boolean:     {type: 'boolean'},
+    character:   {type: 'string'},
+    date:        {type: 'string'},
+    bigint:      {type: 'integer'},
+    integer:     {type: 'integer'},
+    json:        {type: 'object'},
+    jsonb:       {type: 'object'},
+    numeric:     {type: 'number'},
+    real:        {type: 'number'},
+    smallint:    {type: 'integer'},
+    smallserial: {type: 'integer'},
+    serial:      {type: 'integer'},
+    text:        {type: 'string'},
+
+    'character varying':           {type: 'string'},
+    'double precision':            {type: 'number'},
+    'time without time zone':      {type: 'string', format: 'date-time'},
+    'time with time zone':         {type: 'string', format: 'date-time'},
+    'timestamp without time zone': {type: 'string', format: 'date-time'},
+    'timestamp with time zone':    {type: 'string', format: 'date-time'}
   };
 
   return {
-    [column.name]: {
-      type: TYPES[column.type]
-    }
+    [column.name]: TYPES[column.type]
   };
 }
 


### PR DESCRIPTION
Time(stamp)s with(out) time zone are now treated as type 'string' with format 'date-time' in
generated JSON Schema