### PR TITLE
Updated typings version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 <div id="badges" align="center"></div>
+[![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 
 # Collimator
 

--- a/docs/interfaces/_collimator_.fulltabledescription.html
+++ b/docs/interfaces/_collimator_.fulltabledescription.html
@@ -116,7 +116,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_inspectors_tables_.tabledescription.html">TableDescription</a>.<a href="_inspectors_tables_.tabledescription.html#name">name</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/warrenseymour/collimator/blob/HEAD/src/inspectors/tables.ts#L12">inspectors/tables.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/Jstillerman/collimator/blob/update-typings/src/inspectors/tables.ts#L12">inspectors/tables.ts:12</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -132,7 +132,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_inspectors_tables_.tabledescription.html">TableDescription</a>.<a href="_inspectors_tables_.tabledescription.html#primarykeys">primaryKeys</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/warrenseymour/collimator/blob/HEAD/src/inspectors/tables.ts#L16">inspectors/tables.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/Jstillerman/collimator/blob/update-typings/src/inspectors/tables.ts#L16">inspectors/tables.ts:16</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -144,10 +144,10 @@
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface">
 					<a name="relationships" class="tsd-anchor"></a>
 					<h3>relationships</h3>
-					<div class="tsd-signature tsd-kind-icon">relationships<span class="tsd-signature-symbol">:</span> <a href="_inspectors_relationships_.relationships.html" class="tsd-signature-type">Relationships</a><span class="tsd-signature-symbol">[]</span></div>
+					<div class="tsd-signature tsd-kind-icon">relationships<span class="tsd-signature-symbol">:</span> <a href="_inspectors_relationships_.relationships.html" class="tsd-signature-type">Relationships</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/warrenseymour/collimator/blob/HEAD/src/collimator.ts#L15">collimator.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/Jstillerman/collimator/blob/update-typings/src/collimator.ts#L15">collimator.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -157,7 +157,7 @@
 					<div class="tsd-signature tsd-kind-icon">schema<span class="tsd-signature-symbol">:</span> <a href="_inspectors_schema_.schemadocument.html" class="tsd-signature-type">SchemaDocument</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/warrenseymour/collimator/blob/HEAD/src/collimator.ts#L14">collimator.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/Jstillerman/collimator/blob/update-typings/src/collimator.ts#L14">collimator.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_inspectors_relationships_.relationship.html
+++ b/docs/interfaces/_inspectors_relationships_.relationship.html
@@ -108,7 +108,7 @@
 					<div class="tsd-signature tsd-kind-icon">from<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/warrenseymour/collimator/blob/HEAD/src/inspectors/relationships.ts#L17">inspectors/relationships.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/Jstillerman/collimator/blob/update-typings/src/inspectors/relationships.ts#L17">inspectors/relationships.ts:17</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/warrenseymour/collimator/blob/HEAD/src/inspectors/relationships.ts#L13">inspectors/relationships.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/Jstillerman/collimator/blob/update-typings/src/inspectors/relationships.ts#L13">inspectors/relationships.ts:13</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -138,7 +138,7 @@
 					<div class="tsd-signature tsd-kind-icon">to<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/warrenseymour/collimator/blob/HEAD/src/inspectors/relationships.ts#L21">inspectors/relationships.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/Jstillerman/collimator/blob/update-typings/src/inspectors/relationships.ts#L21">inspectors/relationships.ts:21</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/_inspectors_relationships_.relationships.html
+++ b/docs/interfaces/_inspectors_relationships_.relationships.html
@@ -107,7 +107,7 @@
 					<div class="tsd-signature tsd-kind-icon">belongs<wbr>To<span class="tsd-signature-symbol">:</span> <a href="_inspectors_relationships_.relationship.html" class="tsd-signature-type">Relationship</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/warrenseymour/collimator/blob/HEAD/src/inspectors/relationships.ts#L31">inspectors/relationships.ts:31</a></li>
+							<li>Defined in <a href="https://github.com/Jstillerman/collimator/blob/update-typings/src/inspectors/relationships.ts#L31">inspectors/relationships.ts:31</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">has<span class="tsd-signature-symbol">:</span> <a href="_inspectors_relationships_.relationship.html" class="tsd-signature-type">Relationship</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/warrenseymour/collimator/blob/HEAD/src/inspectors/relationships.ts#L35">inspectors/relationships.ts:35</a></li>
+							<li>Defined in <a href="https://github.com/Jstillerman/collimator/blob/update-typings/src/inspectors/relationships.ts#L35">inspectors/relationships.ts:35</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/_inspectors_schema_.column.html
+++ b/docs/interfaces/_inspectors_schema_.column.html
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">default<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/warrenseymour/collimator/blob/HEAD/src/inspectors/schema.ts#L14">inspectors/schema.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/Jstillerman/collimator/blob/update-typings/src/inspectors/schema.ts#L14">inspectors/schema.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/warrenseymour/collimator/blob/HEAD/src/inspectors/schema.ts#L11">inspectors/schema.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/Jstillerman/collimator/blob/update-typings/src/inspectors/schema.ts#L11">inspectors/schema.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">nullable<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/warrenseymour/collimator/blob/HEAD/src/inspectors/schema.ts#L13">inspectors/schema.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/Jstillerman/collimator/blob/update-typings/src/inspectors/schema.ts#L13">inspectors/schema.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/warrenseymour/collimator/blob/HEAD/src/inspectors/schema.ts#L12">inspectors/schema.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/Jstillerman/collimator/blob/update-typings/src/inspectors/schema.ts#L12">inspectors/schema.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_inspectors_schema_.schemadocument.html
+++ b/docs/interfaces/_inspectors_schema_.schemadocument.html
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">$schema<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/warrenseymour/collimator/blob/HEAD/src/inspectors/schema.ts#L21">inspectors/schema.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/Jstillerman/collimator/blob/update-typings/src/inspectors/schema.ts#L21">inspectors/schema.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">properties<span class="tsd-signature-symbol">:</span> <a href="_inspectors_schema_.schemaproperties.html" class="tsd-signature-type">SchemaProperties</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/warrenseymour/collimator/blob/HEAD/src/inspectors/schema.ts#L24">inspectors/schema.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/Jstillerman/collimator/blob/update-typings/src/inspectors/schema.ts#L24">inspectors/schema.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">required<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/warrenseymour/collimator/blob/HEAD/src/inspectors/schema.ts#L25">inspectors/schema.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/Jstillerman/collimator/blob/update-typings/src/inspectors/schema.ts#L25">inspectors/schema.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">title<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/warrenseymour/collimator/blob/HEAD/src/inspectors/schema.ts#L22">inspectors/schema.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/Jstillerman/collimator/blob/update-typings/src/inspectors/schema.ts#L22">inspectors/schema.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -150,7 +150,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/warrenseymour/collimator/blob/HEAD/src/inspectors/schema.ts#L23">inspectors/schema.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/Jstillerman/collimator/blob/update-typings/src/inspectors/schema.ts#L23">inspectors/schema.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_inspectors_tables_.tabledescription.html
+++ b/docs/interfaces/_inspectors_tables_.tabledescription.html
@@ -112,7 +112,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/warrenseymour/collimator/blob/HEAD/src/inspectors/tables.ts#L12">inspectors/tables.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/Jstillerman/collimator/blob/update-typings/src/inspectors/tables.ts#L12">inspectors/tables.ts:12</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -127,7 +127,7 @@
 					<div class="tsd-signature tsd-kind-icon">primary<wbr>Keys<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/warrenseymour/collimator/blob/HEAD/src/inspectors/tables.ts#L16">inspectors/tables.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/Jstillerman/collimator/blob/update-typings/src/inspectors/tables.ts#L16">inspectors/tables.ts:16</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/modules/_collimator_.html
+++ b/docs/modules/_collimator_.html
@@ -98,7 +98,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/warrenseymour/collimator/blob/HEAD/src/collimator.ts#L25">collimator.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/Jstillerman/collimator/blob/update-typings/src/collimator.ts#L25">collimator.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_inspectors_relationships_.html
+++ b/docs/modules/_inspectors_relationships_.html
@@ -99,7 +99,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/warrenseymour/collimator/blob/HEAD/src/inspectors/relationships.ts#L47">inspectors/relationships.ts:47</a></li>
+									<li>Defined in <a href="https://github.com/Jstillerman/collimator/blob/update-typings/src/inspectors/relationships.ts#L47">inspectors/relationships.ts:47</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_inspectors_schema_.html
+++ b/docs/modules/_inspectors_schema_.html
@@ -104,7 +104,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/warrenseymour/collimator/blob/HEAD/src/inspectors/schema.ts#L76">inspectors/schema.ts:76</a></li>
+									<li>Defined in <a href="https://github.com/Jstillerman/collimator/blob/update-typings/src/inspectors/schema.ts#L76">inspectors/schema.ts:76</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -137,7 +137,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/warrenseymour/collimator/blob/HEAD/src/inspectors/schema.ts#L87">inspectors/schema.ts:87</a></li>
+									<li>Defined in <a href="https://github.com/Jstillerman/collimator/blob/update-typings/src/inspectors/schema.ts#L87">inspectors/schema.ts:87</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -169,7 +169,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/warrenseymour/collimator/blob/HEAD/src/inspectors/schema.ts#L124">inspectors/schema.ts:124</a></li>
+									<li>Defined in <a href="https://github.com/Jstillerman/collimator/blob/update-typings/src/inspectors/schema.ts#L124">inspectors/schema.ts:124</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -202,7 +202,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/warrenseymour/collimator/blob/HEAD/src/inspectors/schema.ts#L47">inspectors/schema.ts:47</a></li>
+									<li>Defined in <a href="https://github.com/Jstillerman/collimator/blob/update-typings/src/inspectors/schema.ts#L47">inspectors/schema.ts:47</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -243,7 +243,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/warrenseymour/collimator/blob/HEAD/src/inspectors/schema.ts#L59">inspectors/schema.ts:59</a></li>
+									<li>Defined in <a href="https://github.com/Jstillerman/collimator/blob/update-typings/src/inspectors/schema.ts#L59">inspectors/schema.ts:59</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_inspectors_tables_.html
+++ b/docs/modules/_inspectors_tables_.html
@@ -98,7 +98,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/warrenseymour/collimator/blob/HEAD/src/inspectors/tables.ts#L27">inspectors/tables.ts:27</a></li>
+									<li>Defined in <a href="https://github.com/Jstillerman/collimator/blob/update-typings/src/inspectors/tables.ts#L27">inspectors/tables.ts:27</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_util_filequery_.html
+++ b/docs/modules/_util_filequery_.html
@@ -92,7 +92,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/warrenseymour/collimator/blob/HEAD/src/util/fileQuery.ts#L16">util/fileQuery.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/Jstillerman/collimator/blob/update-typings/src/util/fileQuery.ts#L16">util/fileQuery.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -46,7 +46,7 @@ gulp.task('style', () => {
 gulp.task('docs', () => {
   var sources = [
     config.paths.src,
-    './typings/main.d.ts'
+    './typings/index.d.ts'
   ];
 
   var options = {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "require-dir": "^0.3.0",
     "semantic-release": "^4.3.5",
     "typedoc": "github:sierrasoftworks/typedoc#v1.8.10",
-    "typings": "^0.8.1"
+    "typings": "^1.3.0"
   },
   "babel": {
     "presets": [

--- a/typings.json
+++ b/typings.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "bluebird": "registry:npm/bluebird#3.3.4+20160427051630"
   },
-  "ambientDependencies": {
+  "globalDependencies": {
     "callsite": "registry:dt/callsite#1.0.0+20160316171810",
     "ext-promise": "github:vitaly-t/pg-promise/typescript/ext-promise.d.ts#4764c45",
     "jasmine": "registry:dt/jasmine#2.2.0+20160412134438",


### PR DESCRIPTION
Updates typings from 0.X to 1.3.0

Typings 1.X renamed `ambientDepenencies` to `globalDependencies`
fixes #48 