### PR TITLE
feat(schema): Set `readOnly` on columns that are a sequential primary key

### DIFF
--- a/integration-test/index.js
+++ b/integration-test/index.js
@@ -16,7 +16,7 @@ var expected = {
       type: 'object',
 
       properties: {
-        id: {type: 'integer'},
+        id: {type: 'integer', readOnly: true},
         username: {type: 'string'},
         password: {type: 'string'},
         created_at: {
@@ -37,10 +37,13 @@ var expected = {
         name: 'tasks',
         from: 'id',
         to: 'owner'
+      }, {
+        name: 'task_watchers',
+        from: 'id',
+        to: 'user_id'
       }]
     }
-  },
-  {
+  }, {
     name: 'tasks',
     primaryKeys: ['id'],
     schema: {
@@ -49,7 +52,8 @@ var expected = {
       type: 'object',
       properties: {
         id: {
-          type: 'integer'
+          type: 'integer',
+          readOnly: true
         },
         title: {
           type: 'string'
@@ -78,6 +82,39 @@ var expected = {
       belongsTo: [{
         name: 'users',
         from: 'owner',
+        to: 'id'
+      }],
+      has: [{
+        name: 'task_watchers',
+        from: 'id',
+        to: 'task_id'
+      }]
+    }
+  }, {
+    name: 'task_watchers',
+    primaryKeys: ['task_id', 'user_id'],
+    schema: {
+      $schema: 'http://json-schema.org/draft-04/schema#',
+      title: 'task_watchers',
+      type: 'object',
+      properties: {
+        user_id: {
+          type: 'integer'
+        },
+        task_id: {
+          type: 'integer'
+        }
+      },
+      required: ['user_id', 'task_id']
+    },
+    relationships: {
+      belongsTo: [{
+        name: 'users',
+        from: 'user_id',
+        to: 'id'
+      }, {
+        name: 'tasks',
+        from: 'task_id',
         to: 'id'
       }],
       has: []

--- a/integration-test/setup.sql
+++ b/integration-test/setup.sql
@@ -23,6 +23,13 @@ CREATE TABLE users
   PRIMARY KEY (id)
 );
 
+CREATE TABLE task_watchers
+(
+  user_id integer NOT NULL,
+  task_id integer NOT NULL,
+  PRIMARY key (user_id, task_id)
+);
+
 CREATE VIEW completed_tasks AS
 SELECT
   users.id,
@@ -37,3 +44,5 @@ GROUP BY
   users.id;
 
 ALTER TABLE tasks ADD FOREIGN KEY (owner) REFERENCES users;
+ALTER TABLE task_watchers ADD FOREIGN KEY (user_id) REFERENCES users;
+ALTER TABLE task_watchers ADD FOREIGN KEY (task_id) REFERENCES tasks;

--- a/spec/inspectors/schema.ts
+++ b/spec/inspectors/schema.ts
@@ -14,10 +14,10 @@ describe('schema', () => {
   var mocks:any = {
     database: 'mockDatabase' as any as IDatabase<any>,
     columns: <Column[]>[
-      {name: 'forename', nullable: false, default: null, type: 'character varying'},
-      {name: 'surname',  nullable: false, default: null, type: 'character varying'},
-      {name: 'age',      nullable: false, default: 30,   type: 'smallint'},
-      {name: 'gender',   nullable: true,  default: null, type: 'character'}
+      {name: 'forename', nullable: false, default: null, type: 'character varying', isprimarykey: false},
+      {name: 'surname',  nullable: false, default: null, type: 'character varying', isprimarykey: false},
+      {name: 'age',      nullable: false, default: 30,   type: 'smallint', isprimarykey: false},
+      {name: 'gender',   nullable: true,  default: null, type: 'character', isprimarykey: false}
     ]
   };
 
@@ -99,7 +99,8 @@ describe('schema', () => {
         name:     'date_of_birth',
         nullable: false,
         default:  null,
-        type:     'time without time zone'
+        type:     'time without time zone',
+        isprimarykey: false
       });
 
       expect(result).toEqual({
@@ -115,7 +116,8 @@ describe('schema', () => {
         name:     'time_taken',
         nullable: false,
         default:  null,
-        type:     'interval'
+        type:     'interval',
+        isprimarykey: false
       });
 
       expect(result).toEqual({
@@ -135,6 +137,23 @@ describe('schema', () => {
           }
         }
       })
+    });
+
+    it('declares columns that are primary keys and have a default that uses a sequence as `readOnly`', () => {
+      var result = property({
+        name: 'id',
+        nullable: false,
+        default: "nextval('test_id_seq'::regclass)",
+        type: 'integer',
+        isprimarykey: true
+      });
+
+      expect(result).toEqual({
+        id: {
+          type: 'integer',
+          readOnly: true
+        }
+      });
     });
   });
 

--- a/src/inspectors/schema.sql
+++ b/src/inspectors/schema.sql
@@ -5,7 +5,8 @@ SELECT
   columns.column_default AS default,
   columns.is_nullable::boolean AS nullable,
   columns.character_maximum_length AS length,
-  attributes.attndims AS dimensions
+  attributes.attndims AS dimensions,
+  indexes.indisprimary AS isPrimaryKey
 
 FROM information_schema.columns AS columns
 
@@ -13,6 +14,10 @@ JOIN pg_catalog.pg_attribute AS attributes
 ON attributes.attrelid = columns.table_name::regclass
 AND attributes.attname = columns.column_name
 AND NOT attributes.attisdropped
+
+LEFT JOIN pg_catalog.pg_index AS indexes
+ON indexes.indrelid = attributes.attrelid
+AND attributes.attnum = ANY(indexes.indkey)
 
 WHERE columns.table_schema = 'public'
 AND columns.table_name = ${name}

--- a/src/inspectors/schema.ts
+++ b/src/inspectors/schema.ts
@@ -12,6 +12,7 @@ export interface Column {
   type:     string;
   nullable: boolean;
   default:  string | number;
+  isprimarykey: boolean;
 }
 
 /**
@@ -125,8 +126,19 @@ export function property(column: Column): SchemaProperties {
     'timestamp with time zone':    {type: 'string', format: 'date-time'}
   };
 
+  var col = TYPES[column.type];
+
+  var isPrimary = column.isprimarykey &&
+    column.nullable === false &&
+    typeof column.default === 'string' &&
+    (column.default as string).startsWith('nextval');
+
+  if (isPrimary) {
+    col.readOnly = true;
+  }
+
   return {
-    [column.name]: TYPES[column.type]
+    [column.name]: col
   };
 }
 


### PR DESCRIPTION
When a column is used as the primary key for a table and is sourced by a sequence, then set
`readOnly: true` in the property definition that appears in the generated schema.