### PR TITLE
feat(schema): Implement enum properties when using CHECK constraints

### DIFF
--- a/integration-test/index.js
+++ b/integration-test/index.js
@@ -61,8 +61,9 @@ var expected = {
         description: {
           type: 'string'
         },
-        complete: {
-          type: 'boolean'
+        status: {
+          type: 'string',
+          enum: ['new', 'started', 'complete']
         },
         created_at: {
           type: 'string',

--- a/integration-test/setup.sql
+++ b/integration-test/setup.sql
@@ -6,11 +6,17 @@ CREATE TABLE tasks
   id serial,
   title character varying(255) NOT NULL,
   description character varying(255),
-  complete boolean NOT NULL DEFAULT false,
+  status text,
   created_at timestamp with time zone DEFAULT now(),
   updated_at timestamp with time zone DEFAULT now(),
   owner integer NOT NULL,
-  PRIMARY KEY (id)
+  PRIMARY KEY (id),
+
+  CONSTRAINT status_is_valid CHECK (
+    status = any(
+      array['new', 'started', 'complete']
+    )
+  )
 );
 
 CREATE TABLE users
@@ -39,7 +45,7 @@ FROM tasks
 INNER JOIN users
   ON users.id = tasks.owner
 WHERE
-  tasks.complete = true
+  tasks.status = 'complete'
 GROUP BY
   users.id;
 

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   "dependencies": {
     "bluebird": "^3.3.4",
     "callsite": "^1.0.0",
-    "ramda": "^0.19.1"
+    "ramda": "^0.22.1"
   },
   "scripts": {
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"

--- a/spec/inspectors/schema.ts
+++ b/spec/inspectors/schema.ts
@@ -155,6 +155,26 @@ describe('schema', () => {
         }
       });
     });
+
+    it('declares columns that use a CHECK constraint to match an array of values as `enum`', () => {
+      var result = property({
+        name: 'status',
+        nullable: false,
+        default: null,
+        type: 'text',
+        isprimarykey: false,
+        constraints: [
+          "(status = ANY (ARRAY['new'::text, 'started'::text, 'complete'::text]))"
+        ]
+      });
+
+      expect(result).toEqual({
+        status: {
+          type: 'string',
+          enum: ['new', 'started', 'complete']
+        }
+      });
+    });
   });
 
   describe('.required()', () => {


### PR DESCRIPTION
Allows the Schema inspector to analyze CHECK contraints on a column to determine if the associated
schema property can be given 'enum' values