### PR TITLE
feat(schema): Replace 'integer' property type with 'number'

### DIFF
--- a/integration-test/index.js
+++ b/integration-test/index.js
@@ -16,7 +16,7 @@ var expected = {
       type: 'object',
 
       properties: {
-        id: {type: 'integer', readOnly: true},
+        id: {type: 'number', readOnly: true},
         username: {type: 'string'},
         password: {type: 'string'},
         created_at: {
@@ -52,7 +52,7 @@ var expected = {
       type: 'object',
       properties: {
         id: {
-          type: 'integer',
+          type: 'number',
           readOnly: true
         },
         title: {
@@ -74,7 +74,7 @@ var expected = {
           format: 'date-time'
         },
         owner: {
-          type: 'integer'
+          type: 'number'
         }
       },
       required: ['title', 'owner']
@@ -100,10 +100,10 @@ var expected = {
       type: 'object',
       properties: {
         user_id: {
-          type: 'integer'
+          type: 'number'
         },
         task_id: {
-          type: 'integer'
+          type: 'number'
         }
       },
       required: ['user_id', 'task_id']
@@ -130,13 +130,13 @@ var expected = {
 
       properties: {
         id: {
-          type: 'integer'
+          type: 'number'
         },
         username: {
           type: 'string'
         },
         completed: {
-          type: 'integer'
+          type: 'number'
         }
       },
 

--- a/spec/inspectors/schema.ts
+++ b/spec/inspectors/schema.ts
@@ -127,13 +127,13 @@ describe('schema', () => {
           minProperties: 1,
           additionalProperties: false,
           properties: {
-            milliseconds: {type: 'integer'},
-            seconds: {type: 'integer'},
-            minutes: {type: 'integer'},
-            hours:   {type: 'integer'},
-            days:    {type: 'integer'},
-            months:  {type: 'ingeger'},
-            years:   {type: 'integer'}
+            milliseconds: {type: 'number'},
+            seconds: {type: 'number'},
+            minutes: {type: 'number'},
+            hours:   {type: 'number'},
+            days:    {type: 'number'},
+            months:  {type: 'number'},
+            years:   {type: 'number'}
           }
         }
       })
@@ -150,7 +150,7 @@ describe('schema', () => {
 
       expect(result).toEqual({
         id: {
-          type: 'integer',
+          type: 'number',
           readOnly: true
         }
       });

--- a/src/inspectors/schema.ts
+++ b/src/inspectors/schema.ts
@@ -96,18 +96,18 @@ export function properties(columns: Column[]): SchemaProperties {
  */
 export function property(column: Column): SchemaProperties {
   const TYPES:any = {
-    bigserial:   {type: 'integer'},
+    bigserial:   {type: 'number'},
     boolean:     {type: 'boolean'},
     character:   {type: 'string'},
-    bigint:      {type: 'integer'},
-    integer:     {type: 'integer'},
+    bigint:      {type: 'number'},
+    integer:     {type: 'number'},
     json:        {type: 'object'},
     jsonb:       {type: 'object'},
     numeric:     {type: 'number'},
     real:        {type: 'number'},
-    smallint:    {type: 'integer'},
-    smallserial: {type: 'integer'},
-    serial:      {type: 'integer'},
+    smallint:    {type: 'number'},
+    smallserial: {type: 'number'},
+    serial:      {type: 'number'},
     text:        {type: 'string'},
 
     interval: {
@@ -116,13 +116,13 @@ export function property(column: Column): SchemaProperties {
       minProperties: 1,
       additionalProperties: false,
       properties: {
-        milliseconds: {type: 'integer'},
-        seconds: {type: 'integer'},
-        minutes: {type: 'integer'},
-        hours:   {type: 'integer'},
-        days:    {type: 'integer'},
-        months:  {type: 'ingeger'},
-        years:   {type: 'integer'}
+        milliseconds: {type: 'number'},
+        seconds: {type: 'number'},
+        minutes: {type: 'number'},
+        hours:   {type: 'number'},
+        days:    {type: 'number'},
+        months:  {type: 'number'},
+        years:   {type: 'number'}
       }
     },
 


### PR DESCRIPTION
'integer' is not part of the JSON Schema spec, only 'number' is. JavaScript has no concept of
integers vs floats, etc.

Erroneous 'integer' type has been removed. All numeric columns are now emitted as 'number'.