### PR TITLE
fix(schema): Make enum inspection more robust

### DIFF
--- a/integration-test/setup.sql
+++ b/integration-test/setup.sql
@@ -16,6 +16,10 @@ CREATE TABLE tasks
     status = any(
       array['new', 'started', 'complete']
     )
+  ),
+
+  CONSTRAINT updated_at_in_future CHECK (
+    updated_at > NOW()
   )
 );
 

--- a/src/inspectors/schema.ts
+++ b/src/inspectors/schema.ts
@@ -183,12 +183,12 @@ export function isEnumConstraint(column: Column) {
         return;
       }
 
-      var [match, values] = constraint.match(ENUM_CHECK_REGEX);
-      if (!values) {
+      var result = constraint.match(ENUM_CHECK_REGEX);
+      if (!result || !result[1]) {
         return;
       }
 
-      return values.split(', ')
+      return result[1].split(', ')
         .map(value => {
           var [match, value] = value.match(ENUM_EXTRACT_VALUE_REGEX);
           return value;


### PR DESCRIPTION
`isEnumConstraint` would throw an error due to destructuring `null` for CHECK constraints that do
not match the regex