### PR TITLE
feat(schema): Use 'string' for bigserial and biginteger

### DIFF
--- a/integration-test/index.js
+++ b/integration-test/index.js
@@ -136,7 +136,8 @@ var expected = {
           type: 'string'
         },
         completed: {
-          type: 'number'
+          type: 'string',
+          pattern: '^\\d+$'
         }
       },
 

--- a/src/inspectors/schema.ts
+++ b/src/inspectors/schema.ts
@@ -96,10 +96,10 @@ export function properties(columns: Column[]): SchemaProperties {
  */
 export function property(column: Column): SchemaProperties {
   const TYPES:any = {
-    bigserial:   {type: 'number'},
+    bigserial:   {type: 'string', pattern: '^\\d+$'},
     boolean:     {type: 'boolean'},
     character:   {type: 'string'},
-    bigint:      {type: 'number'},
+    bigint:      {type: 'string', pattern: '^\\d+$'},
     integer:     {type: 'number'},
     json:        {type: 'object'},
     jsonb:       {type: 'object'},


### PR DESCRIPTION
PostgreSQL's 'bigserial' and 'bigint' types are 64-bit. This can't be expressed with JavaScript's
'Number' type, so a 'string' type with a pattern should be used instead.

BREAKING CHANGE: Columns that are of 'bigint' or 'bigserial' types will now be described in the JSON Schema
document as 'string' instead of 'number'.