### PR TITLE
feat: Add loose number types

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ Extract relationship information with `collimator.relationships(db, 'tableName')
 
 The top-level Collimator functions (`tables`, `schema` and `relationships`) accept a [pg-promise][pg-promise] `Database` instance as their first argument, and return a promise. For further guidance, please refer to the [examples][examples] and [API Documentation][api-docs].
 
+### Options
+
+`collimator.tables()` also accepts a second optional `options` parameter. The following options are supported:
+
+- `looseNumbers` - when `true`, then 'loose number' mode will be enabled. In
+  this mode, numeric column types will be rendered to the JSON Schema document
+  as `{oneOf: [{type: 'number'}, {type: 'string', pattern: ...}]}`.
+
+  If the column is an integer or similar, then the regular expression `^\d+$`
+  will be used. For decimals, `^[1-9]\d*(\.\d+)?$` will be used.
+
 [pg-promise]: https://www.npmjs.com/package/pg-promise
 [examples]: https://github.com/radify/collimator/tree/master/examples
 [api-docs]: https://github.com/radify/collimator/blob/master/docs/API.md

--- a/src/collimator.ts
+++ b/src/collimator.ts
@@ -1,12 +1,12 @@
-import Promise, {props} from 'bluebird';
-import {IDatabase} from 'pg-promise';
-import {merge}     from 'ramda';
+import Promise, { props } from 'bluebird';
+import { IDatabase } from 'pg-promise';
+import { merge } from 'ramda';
 
-import views,  {ViewDescription}      from './inspectors/views';
-import tables, {TableDescription}     from './inspectors/tables';
-import schema, {SchemaDocument}       from './inspectors/schema';
-import usedTables, {UsedTable}        from './inspectors/usedTables';
-import relationships, {Relationships} from './inspectors/relationships';
+import views, { ViewDescription } from './inspectors/views';
+import tables, { TableDescription } from './inspectors/tables';
+import schema, { SchemaDocument } from './inspectors/schema';
+import usedTables, { UsedTable } from './inspectors/usedTables';
+import relationships, { Relationships } from './inspectors/relationships';
 
 /**
  * Extended description of a Table that includes information about the table
@@ -31,31 +31,43 @@ export interface InspectResult {
 }
 
 /**
+ * Options to supply to inspectors
+ */
+export interface Options {
+  /**
+   * If `true`, then allow numeric types emitted in schema to be oneOf `number`
+   * or `string` with a pattern
+   */
+  looseNumbers?: boolean;
+}
+
+/**
  * Inspect all enumerable table in a database, and return a promise that will
  * resolve to information about each table.
  *
  * @param db A pg-promise database instance
+ * @param options Options to supply to inspector functions
  * @returns  A promise that will resolve to the information for each table
  */
-export function inspect(db: IDatabase<any>): Promise<InspectResult> {
+export function inspect(db: IDatabase<any>, options: Options = {}): Promise<InspectResult> {
   const inspectTable = (table: TableDescription) =>
     (props({
       schema: schema(db, table.name),
       relationships: relationships(db, table.name)
     }) as Promise<ExtendedTableDescription>)
-    .then(merge(table));
+      .then(merge(table));
 
   const inspectView = (view: ViewDescription) =>
     (props({
       schema: schema(db, view.name),
       uses: usedTables(db, view.name),
     }) as Promise<ExtendedViewDescription>)
-    .then(merge(view));
+      .then(merge(view));
 
   return props({
     tables: tables(db).map(inspectTable),
-    views:  views(db).map(inspectView)
+    views: views(db).map(inspectView)
   }) as Promise<InspectResult>;
 }
 
-export {tables, schema, relationships};
+export { tables, schema, relationships };


### PR DESCRIPTION
Added second 'options' parameter to top-level 'inspect' function, which
propagates down to 'schema.property'.

When options.looseNumbers is true, then numeric strings will be rendered
in JSON schema as oneOf 'number' OR 'string', with an appropriate
regular expression pattern.

Options may be safely omitted by default, and 'looseNumbers' must be
explicitly turned on, preserving backwards compatibility.