### PR TITLE
Nullable Types

### DIFF
--- a/integration-test/index.js
+++ b/integration-test/index.js
@@ -20,11 +20,11 @@ var expected = {
         username: {type: 'string'},
         password: {type: 'string'},
         created_at: {
-          type: 'string',
+          type: ['string', 'null'],
           format: 'date-time'
         },
         updated_at: {
-          type: 'string',
+          type: ['string', 'null'],
           format: 'date-time'
         },
       },
@@ -59,18 +59,18 @@ var expected = {
           type: 'string'
         },
         description: {
-          type: 'string'
+          type: ['string', 'null']
         },
         status: {
-          type: 'string',
+          type: ['string', 'null'],
           enum: ['new', 'started', 'complete']
         },
         created_at: {
-          type: 'string',
+          type: ['string', 'null'],
           format: 'date-time'
         },
         updated_at: {
-          type: 'string',
+          type: ['string', 'null'],
           format: 'date-time'
         },
         owner: {
@@ -130,13 +130,13 @@ var expected = {
 
       properties: {
         id: {
-          type: 'number'
+          type: ['number', 'null']
         },
         username: {
-          type: 'string'
+          type: ['string', 'null']
         },
         completed: {
-          type: 'string',
+          type: ['string', 'null'],
           pattern: '^\\d+$'
         }
       },

--- a/spec/inspectors/schema.ts
+++ b/spec/inspectors/schema.ts
@@ -199,6 +199,8 @@ describe('schema', () => {
             }, {
               type: 'string',
               pattern: '^[1-9]\d*(\.\d+)?$'
+            }, {
+              type: 'null'
             }]
           }
         })


### PR DESCRIPTION
BREAKING CHANGE: Columns that are 'nullable' will now emit a JSON Schema Property that is more semantically correct; instead of a 'plain' type, they will now use a compound type of `[<type>, 'null']`, allowing data to be correctly validated when a value of `null` is passed.